### PR TITLE
Update config.txt for Roche ACCU-CHEK Guide Me

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,4 +1,5 @@
 vendor_0x173a_device_0x21d5 1 # roche accu-Chek model  929
+vendor_0x173a_device_0x21d6 1 # Roche ACCU-CHEK Guide Me
 vendor_0x173a_device_0x21d7 1 # some other similar model with product id 0x21d7 that should also work with this code
 vendor_0x173a_device_0x21cc 1 # Roche Accu-Check Active USB
 


### PR DESCRIPTION
adds support for the Guide Me , an old but reliable model

 sudo ./accuchek
[
    { "id":     0, "epoch": 1690634880, "timestamp":"2023/07/29 13:48", "mg/dL":368, "mmol/L": 20.444444 },
    { "id":     1, "epoch": 1690646880, "timestamp":"2023/07/29 17:08", "mg/dL":364, "mmol/L": 20.222222 },
    { "id":     2, "epoch": 1690695420, "timestamp":"2023/07/30 06:37", "mg/dL":306, "mmol/L": 17.000000 },
    { "id":     3, "epoch": 1690702980, "timestamp":"2023/07/30 08:43", "mg/dL":312, "mmol/L": 17.333333 },

Working on Debian for a Raspberry Pi 3 B

libusb must be installed as 
sudo apt-get install libusb-1.0-0-dev